### PR TITLE
Fix signup 500

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV GUNICORN_EXTRA_FLAGS=''
 
 COPY . /app
 WORKDIR /app
-RUN pip install -r requirements.txt
+RUN pip install setuptools_scm && pip install -r requirements.txt
 RUN chown -R bikeanjo /app
 
 USER bikeanjo

--- a/bikeanjo/settings.py
+++ b/bikeanjo/settings.py
@@ -90,6 +90,10 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
 )
 
+if DEBUG:
+    MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES \
+        + ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+
 ROOT_URLCONF = 'bikeanjo.urls'
 
 TEMPLATES = [

--- a/front/forms.py
+++ b/front/forms.py
@@ -184,10 +184,11 @@ class SignupForm(forms.ModelForm):
     def clean_email2(self):
         email = self.cleaned_data.get('email')
         email2 = self.cleaned_data.get('email2')
-        
 
-        if email.strip() != email2.strip():
-            raise forms.ValidationError(_('The e-mails informed are different.'))
+        # if email is None, Django will thrown an error on clean_email
+        if email is not None:
+            if email.strip() != email2.strip():
+                raise forms.ValidationError(_('The e-mails informed are different.'))
         return email
 
     def clean_first_name(self):


### PR DESCRIPTION
An error happens whenever an existent tries to sign up on the platform. That happens because we try to validate the verification email when it does not exist, because django didn't validate the main email.